### PR TITLE
Update __init__.py

### DIFF
--- a/htd_lync12/__init__.py
+++ b/htd_lync12/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType, Dict
+from homeassistant.helpers.typing import ConfigType
 
 from .htd_lync12 import DEFAULT_HTD_LYNC12_PORT, HtdLync12Client
 


### PR DESCRIPTION
Line 8: removed `Dict` and the trailing comma before 'Dict' as it was causing the following error:

Component error: htd_lync12 - Exception importing custom_components.htd_lync12